### PR TITLE
Upgrade Node & Debian to fix 404s when running and add `git` to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12.0-slim
+FROM node:11-slim
 
 LABEL "com.github.actions.name"="Report to packtracker.io"
 LABEL "com.github.actions.description"="Report your webpack build stats to the packtracker.io service."

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL "com.github.actions.description"="Report your webpack build stats to the p
 LABEL "com.github.actions.icon"="upload-cloud"
 LABEL "com.github.actions.color"="#363636"
 
-RUN apt-get update && apt-get install jq -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install jq git -y && rm -rf /var/lib/apt/lists/*
 
 COPY ./entrypoint.sh /entrypoint.sh
 COPY ./report.js /report.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL "com.github.actions.description"="Report your webpack build stats to the p
 LABEL "com.github.actions.icon"="upload-cloud"
 LABEL "com.github.actions.color"="#363636"
 
-RUN apt-get update && apt-get install jq -y
+RUN apt-get update && apt-get install jq -y && rm -rf /var/lib/apt/lists/*
 
 COPY ./entrypoint.sh /entrypoint.sh
 COPY ./report.js /report.js


### PR DESCRIPTION
Hi Jon, we've been corresponding via email.

These are the changes I had to make to get the GH action working for me. I thought I'd share these back. If I had been preparing these commits for PR at the time, I might have structured these in separate branches, but I thought this might be useful regardless.

Summary:

* Upgrade to Node 11 base image. Importantly, this upgrades the underlying Debian version off Jessie, as the apt package servers were 404ing Jessie packages
* Added `git` to support `yarn`/`npm i` when there are dependencies sourced from Git
* (non-essential) clean up the apt list cache after installing extra deps to keep image smaller